### PR TITLE
Fixes issue where Rook operator fails to start

### DIFF
--- a/manifests/rook-operator.yaml
+++ b/manifests/rook-operator.yaml
@@ -122,3 +122,7 @@ spec:
         # current mon with a new mon (useful for compensating flapping network).
         - name: ROOK_MON_OUT_TIMEOUT
           value: "300s"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace


### PR DESCRIPTION
Adds the POD_NAMESPACE variable to the rook operator manifest
fixes #50 