### PR TITLE
Allow user to specify upgrade strategy

### DIFF
--- a/install-coreos.sh
+++ b/install-coreos.sh
@@ -16,5 +16,6 @@ cat container-linux-config.yaml \
   | sed "s/#HOSTNAME#/$(echo $PUBLIC_IP | sed "s/\./-/g")/g" \
   | sed "s/#GATEWAY#/${PUBLIC_IP%.*}.1/g" \
   | sed "s/#DNS#/$(cat /etc/resolv.conf | awk '/^nameserver /{ print $0 }' | sed 's/nameserver //g' | tr '\n' ' ')/g" \
+  | sed "s/#REBOOT_STRATEGY#/${REBOOT_STRATEGY}/g" \
   | ./ct > container-linux-config.json
 ./coreos-install -d /dev/sda -i container-linux-config.json

--- a/kube-linode.sh
+++ b/kube-linode.sh
@@ -34,6 +34,7 @@ unset MASTER_ID
 unset API_KEY
 unset USERNAME
 unset NO_OF_WORKERS
+unset REBOOT_STRATEGY
 
 stty -echo
 tput civis
@@ -63,6 +64,7 @@ for argument in $options
       --install_traefik=*)         INSTALL_TRAEFIK=${argument/*=/""} ;;
       --install_rook=*)            INSTALL_ROOK=${argument/*=/""} ;;
       --install_prometheus=*)      INSTALL_PROMETHEUS=${argument/*=/""} ;;
+      --reboot_strategy=*)         REBOOT_STRATEGY=${argument/*=/""} ;;
     esac
   done
 
@@ -75,6 +77,8 @@ read_email
 read_no_of_workers
 read_username
 read_install_options
+read_reboot_strategy
+
 
 if [ "$1" == "teardown" ]; then
   spinner "Retrieving master linode (if any)" get_master_id MASTER_ID

--- a/linode-utilities.sh
+++ b/linode-utilities.sh
@@ -223,7 +223,7 @@ install_coreos() {
   while true; do ssh -i ~/.ssh/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${PUBLIC_IP} \
     "chmod +x ./install-coreos.sh" && break || sleep 5; done
   while true; do ssh -i ~/.ssh/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${PUBLIC_IP} \
-    "./install-coreos.sh" && break || sleep 5; done
+    "REBOOT_STRATEGY=${REBOOT_STRATEGY} ./install-coreos.sh" && break || sleep 5; done
   set -e
 }
 
@@ -500,6 +500,15 @@ read_username() {
     echo "USERNAME=$USERNAME" >> settings.env
   fi
   tput civis
+}
+
+read_reboot_strategy() {
+  if [ -z "$REBOOT_STRATEGY" ]; then
+    strategies=("off" "etcd-lock" "reboot")
+    list_input_index "Select a update strategy (see https://coreos.com/os/docs/latest/update-strategies.html)" strategies strategy
+    REBOOT_STRATEGY=${strategies[$strategy]}
+    echo "REBOOT_STRATEGY=$REBOOT_STRATEGY" >> settings.env
+  fi
 }
 
 get_domains() {

--- a/manifests/container-linux/master-config.yaml
+++ b/manifests/container-linux/master-config.yaml
@@ -139,8 +139,6 @@ systemd:
             Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
     - name: docker.service
       enable: true
-    - name: locksmithd.service
-      mask: true
     - name: kubelet.path
       enable: true
       contents: |
@@ -225,3 +223,5 @@ systemd:
         RestartSec=10
         [Install]
         WantedBy=multi-user.target
+locksmith:
+  reboot_strategy: #REBOOT_STRATEGY#

--- a/manifests/container-linux/worker-config.yaml
+++ b/manifests/container-linux/worker-config.yaml
@@ -86,8 +86,6 @@ systemd:
   units:
     - name: docker.service
       enable: true
-    - name: locksmithd.service
-      mask: true
     - name: kubelet.path
       enable: true
       contents: |
@@ -169,3 +167,5 @@ systemd:
         RestartSec=10
         [Install]
         WantedBy=multi-user.target
+locksmith:
+  reboot_strategy: #REBOOT_STRATEGY#


### PR DESCRIPTION
This change allows the locksmith update strategy to be configured, rather than silently setting it to no reboots (and therefore no updates). I wasn't sure how to get the variable from the local machine to the installer script, I'm open to other options (I was thinking it could just be in the argv of the script instead maybe?)