### PR TITLE
Update traefik to fix Let's Encrypt support

### DIFF
--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -128,7 +128,7 @@ spec:
           hostPath:
             path: /etc/traefik/acme
       containers:
-        - image: traefik
+        - image: traefik:v1.5.0-rc5
           name: traefik-ingress-lb
           imagePullPolicy: Always
           volumeMounts:

--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -97,6 +97,8 @@ data:
     onDemand = true
     onHostRule = true
     caServer = "https://acme-v01.api.letsencrypt.org/directory"
+    [acme.httpChallenge]
+      entryPoint = "http"
     [[acme.domains]]
       main = "${DOMAIN}"
     [web]


### PR DESCRIPTION
Updates to the pre-release version of Traefik and adds the required config changes to use HTTP-01 validation, fixes #72 