### PR TITLE
Update manifests / CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Automatically provision a scalable CoreOS/Kubernetes cluster on Linode with zero
 The cluster will comprise of a single Kubernetes master host with a custom number of worker nodes.
 
 ### What's included
-* [Kubernetes 1.9.1](https://kubernetes.io/) with [Bootkube](https://github.com/kubernetes-incubator/bootkube)
+* [Kubernetes 1.9.3](https://kubernetes.io/) with [Bootkube](https://github.com/kubernetes-incubator/bootkube)
 * Load Balancer and automatic SSL/TLS renewal using [Traefik](https://github.com/containous/traefik)
 * Distributed block storage with [Rook](https://github.com/rook/rook)
 * Pre-configured [Grafana](https://github.com/grafana/grafana) dashboard using [Kube-Prometheus](https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus) with Rook and Traefik monitoring
@@ -25,29 +25,21 @@ The cluster will comprise of a single Kubernetes master host with a custom numbe
 git clone https://github.com/kahkhang/kube-linode
 cd kube-linode
 chmod +x kube-linode.sh
-```
-
-Just run `./kube-linode.sh` into your console, key in your configuration, then sit back and have a :coffee:!
-
-Settings are stored in `settings.env`, or you can pass them in as key-value flags as such:
-
+```  
+Just run `./kube-linode.sh create` into your console, key in your configuration, then sit back and have a :coffee:!  
+Settings are stored in `settings.env`, or you can pass them in as key-value flags as such:  
 ```sh
 ./kube-linode.sh --no_of_workers=3 --api_key=12345
-```
-
-To increase the number of workers, modify `NO_OF_WORKERS` in `settings.env` as desired and run `./kube-linode.sh` again.
-
-Use `kubectl` to control the cluster (e.g. `kubectl get nodes`)
-
+```  
+To increase the number of workers, modify `NO_OF_WORKERS` in `settings.env` as desired and run `./kube-linode.sh` again.  
+Use `kubectl` to control the cluster (e.g. `kubectl get nodes`)  
 <hr>
 
-Later, should you want to start over from scratch, or if you just want to stop everything, you can run
-
+If you want to destroy the cluster created by kube-linode, you can run the following command:
 ```sh
-./kube-linode.sh teardown
-```
-
-And all your linodes - everything - will be deleted.
+./kube-linode.sh destroy
+```  
+A prompt will be given listing all the nodes which will be destroyed upon confirmation  .
 
 ### Dependencies
 You should have a Linode account, which you can get [here](https://www.linode.com/?r=0affaec6ca42ca06f5f2c2d3d8d1ceb354e222c1).

--- a/linode-utilities.sh
+++ b/linode-utilities.sh
@@ -430,8 +430,8 @@ read_worker_plan() {
          IFS=$'\n'
          spinner "Retrieving plans" get_plans plan_data
          tput el
-         local plan_ids=($(echo $plan_data | jq -r '.[] | .PLANID'))
-         local plan_list=($(echo $plan_data | jq -r '.[] | [.RAM, .PRICE] | @csv' | \
+         local plan_ids=($(echo $plan_data | jq -r '.[] | select(.RAM >= 2048) | .PLANID'))
+         local plan_list=($(echo $plan_data | jq -r '.[] | select(.RAM >= 2048) | [.RAM, .PRICE] | @csv' | \
            awk -v FS="," '{ram=$1/1024; printf "%3sGB (\$%s/mo)%s",ram,$2,ORS}' 2>/dev/null))
          list_input_index "Select a worker plan (https://www.linode.com/pricing)" plan_list selected_disk_id
 
@@ -587,12 +587,6 @@ create_linode() {
 
 delete_linode() {
   local LINODE_ID="$1"
-  local DISK_IDS=$(get_disk_ids $LINODE_ID)
-
-  for DISK_ID in "$DISK_IDS" ; do
-    linode_api linode.disk.delete LinodeID=$LINODE_ID DiskID=$DISK_ID >/dev/null
-  done
-
   linode_api linode.delete LinodeID=$LINODE_ID skipChecks=true >/dev/null
 }
 

--- a/manifests/alertmanager/alertmanager.yaml
+++ b/manifests/alertmanager/alertmanager.yaml
@@ -6,4 +6,4 @@ metadata:
     alertmanager: main
 spec:
   replicas: 1
-  version: v0.9.1
+  version: v0.14.0

--- a/manifests/container-linux/master-config.yaml
+++ b/manifests/container-linux/master-config.yaml
@@ -28,7 +28,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
-          KUBELET_IMAGE_TAG=v1.9.1
+          KUBELET_IMAGE_TAG=v1.9.3
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -52,7 +52,7 @@ storage:
             rm -rf /opt/bootkube/assets/manifests-*
 
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.9.1}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.9.3}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
 
           # ======== START OF RESOURCE RENDERING ===========

--- a/manifests/container-linux/worker-config.yaml
+++ b/manifests/container-linux/worker-config.yaml
@@ -17,7 +17,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
-          KUBELET_IMAGE_TAG=v1.9.1
+          KUBELET_IMAGE_TAG=v1.9.3
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -35,7 +35,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://gcr.io/google_containers/hyperkube:v1.9.1 \
+            docker://gcr.io/google_containers/hyperkube:v1.9.3 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node #COREOS_PUBLIC_IPV4#

--- a/manifests/heapster.yaml
+++ b/manifests/heapster.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0
+        image: gcr.io/google_containers/heapster-amd64:v1.5.1
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/manifests/kube-dashboard.yaml
+++ b/manifests/kube-dashboard.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.8.1
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.8.3
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/manifests/prometheus-operator/prometheus-operator.yaml
+++ b/manifests/prometheus-operator/prometheus-operator.yaml
@@ -15,7 +15,7 @@ spec:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        image: quay.io/coreos/prometheus-operator:v0.14.1
+        image: quay.io/coreos/prometheus-operator:v0.17.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/manifests/traefik.yaml
+++ b/manifests/traefik.yaml
@@ -130,7 +130,7 @@ spec:
           hostPath:
             path: /etc/traefik/acme
       containers:
-        - image: traefik:v1.5.0-rc5
+        - image: traefik:v1.5.3
           name: traefik-ingress-lb
           imagePullPolicy: Always
           volumeMounts:


### PR DESCRIPTION
Bump various manifests versions, including:
  - Bootkube to 0.9.3
  - Traefik to 1.5.3
  - Hyperkube to 1.9.3
 as well as various kube-linode add-ons

CLI changes:
  - ./kube-linode.sh destroy now lists linodes before deletion, and prompts before any settings are deleted
  - Only ~/.kube/config is deleted upon prompt, instead of deleting the whole ~/.kube directory
  - Fix issues with the exit command causing cursor issues upon exit.

Fixes #84 .